### PR TITLE
I think this should be the right syntax for security groups :)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,7 @@ mixins:
 
 provider_config:
   aws:
-    cli_command: "ec2 sever create"
+    cli_command: "ec2 server create"
    		security-groups:
         default: sg-12345678
         java_app_server: sg-34567890


### PR DESCRIPTION
Also fixes a typo in the readme that someone in #chef pointed out
